### PR TITLE
Update stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - th-pprint-0.2.0.0
-- hw-hspec-hedgehog-0.1.0.8
 - git: https://github.com/myfreeweb/hspec-expectations-pretty-diff.git
   commit: b0f3a8697db5c5a7d9ccf319381bcb8605c5992f
 


### PR DESCRIPTION
Remove `hw-hspec-hedgehog-0.1.0.8` from extra-deps. — Does it have to be there? Let's find out.