### PR TITLE
Allow trailing comma after last union/enum declaration value

### DIFF
--- a/src/FlatBuffers/Internal/Compiler/Parser.hs
+++ b/src/FlatBuffers/Internal/Compiler/Parser.hs
@@ -106,6 +106,9 @@ commaSep p = sepBy p (symbol ",")
 commaSep1 :: Parser a -> Parser (NonEmpty a)
 commaSep1 p = NE.sepBy1 p (symbol ",")
 
+commaSepEndBy1 :: Parser a -> Parser (NonEmpty a)
+commaSepEndBy1 p = NE.sepEndBy1 p (symbol ",")
+
 semi, colon :: Parser ()
 semi = void $ symbol ";"
 colon = void $ symbol ":"
@@ -187,7 +190,7 @@ enumDecl = do
   colon
   t <- typ
   md <- metadata
-  v <- curly (commaSep1 enumVal)
+  v <- curly (commaSepEndBy1 enumVal)
   pure $ EnumDecl i t md v
 
 enumVal :: Parser EnumVal
@@ -198,7 +201,7 @@ unionDecl = do
   rword "union"
   i <- ident
   md <- metadata
-  v <- curly (commaSep1 unionVal)
+  v <- curly (commaSepEndBy1 unionVal)
   pure $ UnionDecl i md v
 
 unionVal :: Parser UnionVal

--- a/test/FlatBuffers/Internal/Compiler/ParserSpec.hs
+++ b/test/FlatBuffers/Internal/Compiler/ParserSpec.hs
@@ -216,6 +216,18 @@ spec =
             ]
           ]
 
+    it "enum declarations (trailing comma)" $
+      [r|
+        enum E : short {
+          X,
+        }
+      |] `parses`
+        Schema
+          []
+          [DeclE $ EnumDecl "E" TInt16 (Metadata [])
+            [ EnumVal "X" Nothing ]
+          ]
+
     it "union declarations" $
       [r|
         union Weapon ( attr ) {
@@ -235,6 +247,20 @@ spec =
               , UnionVal (Just "mace2") (TypeRef "My.Api" "Stick")
               , UnionVal Nothing (TypeRef "" "Axe")
               ]
+          ]
+
+    it "union declarations (trailing comma)" $
+      [r|
+        union U {
+          X,
+        }
+      |] `parses`
+        Schema
+          []
+          [ DeclU $ UnionDecl
+              "U"
+              (Metadata [])
+              [ UnionVal Nothing (TypeRef "" "X") ]
           ]
 
     it "root types, file extensions / identifiers, attribute declarations" $


### PR DESCRIPTION
The official flatbuffers implementation allows trailing commas after values in union/enum declarations. For example:

```
union U {
  X,
}
```

The [grammar](https://google.github.io/flatbuffers/flatbuffers_grammar.html) does not allow this but the developers [say that the grammar is out of date and the implementation is the spec](https://github.com/google/flatbuffers/issues/5455#issuecomment-515162730).

This pull request modifies the union/enum parsers slightly and adds two corresponding test cases.