### PR TITLE
Support Haskell keywords as names of structs/tables

### DIFF
--- a/src/FlatBuffers/Internal/Compiler/NamingConventions.hs
+++ b/src/FlatBuffers/Internal/Compiler/NamingConventions.hs
@@ -3,6 +3,7 @@
 
 module FlatBuffers.Internal.Compiler.NamingConventions where
 
+import qualified Data.Set                                      as Set
 import           Data.Text                                     ( Text )
 import qualified Data.Text                                     as T
 import qualified Data.Text.Manipulate                          as TM
@@ -12,7 +13,7 @@ import           FlatBuffers.Internal.Compiler.ValidSyntaxTree ( EnumDecl, EnumV
 -- Style guide: https://google.github.io/flatbuffers/flatbuffers_guide_writing_schema.html
 
 dataTypeConstructor :: HasIdent a => a -> Text
-dataTypeConstructor = TM.toCamel . unIdent . getIdent
+dataTypeConstructor = replaceKeyword . TM.toCamel . unIdent . getIdent
 
 arg :: HasIdent a => a -> Text
 arg = TM.toCamel . unIdent . getIdent
@@ -69,3 +70,19 @@ withModulePrefix ns text =
     then text
     else namespace ns <> "." <> text
 
+keywords :: Set.Set Text
+keywords = Set.fromList
+  [ "as" , "case", "class", "data", "default", "deriving", "do"
+  , "else", "hiding", "if", "import", "in", "infix", "infixl"
+  , "infixr", "instance", "let", "module", "newtype", "of", "qualified"
+  , "then", "type", "where", "forall", "mdo", "family", "role"
+  , "pattern", "static", "stock", "anyclass", "via", "group", "by"
+  , "using", "foreign", "export", "label", "dynamic", "safe"
+  , "interruptible", "unsafe", "stdcall", "ccall", "capi", "prim"
+  , "javascript", "unit", "dependency", "signature", "rec", "proc"
+  ]
+
+replaceKeyword :: Text -> Text
+replaceKeyword x
+  | x `Set.member` keywords = x <> "_"
+  | otherwise = x

--- a/test/FlatBuffers/Internal/Compiler/THSpec.hs
+++ b/test/FlatBuffers/Internal/Compiler/THSpec.hs
@@ -70,6 +70,14 @@ spec =
         [r| table SomePerson   { PersonAge: int;  }|] `shouldCompileTo` expected
         [r| table somePerson   { personAge: int;  }|] `shouldCompileTo` expected
 
+      it "with keyword as name" $
+        [r| table Type {} |] `shouldCompileTo`
+        [d|
+          data Type
+          type_ :: WriteTable Type
+          type_ = writeTable []
+        |]
+
       describe "numeric fields + boolean" $ do
         it "normal fields" $
           [r|
@@ -1274,6 +1282,21 @@ spec =
             s2X :: Struct S2 -> Either ReadError Int8
             s2X = readStructField readInt8 0
           |]
+
+      it "with keyword as name" $
+        [r| struct Type { x : byte; } |] `shouldCompileTo`
+        [d|
+          data Type
+          instance IsStruct Type
+              where structAlignmentOf = 1
+                    structSizeOf = 1
+
+          type_ :: Int8 -> WriteStruct Type
+          type_ x = WriteStruct (buildInt8 x)
+
+          typeX :: Struct Type -> Either ReadError Int8
+          typeX = readStructField readInt8 0
+        |]
 
     describe "Unions" $
       it "naming conventions" $ do


### PR DESCRIPTION
haskell-flatbuffers can't currently handle types whose names match Haskell keywords. For example, with the following schema:

```
table Type {}
```

an error is raised because the smart constructor for `Type` is named `type` which is a Haskell keyword:

```
Illegal variable name: ‘type’
When splicing a TH declaration:
  type :: FlatBuffers.Internal.Write.WriteTable Type
```

It seems that this is an issue with tables and structs only due to the generated smart constructors. Other generated functions are named using a combination of the type and field/value name which I would guess is less problematic.

flatc adds an underscore to a name in this case. For example, in the case of `table class {}` the generated C++ code contains `struct class_;`.

This pull request modifies `FlatBuffers.Internal.Compiler.NamingConventions` to add an underscore after a data type constructor if the name matches a Haskell keyword. The keywords list is taken from [the GHC lexer](https://github.com/ghc/ghc/blob/master/compiler/GHC/Parser/Lexer.x). The list is missing the `_` keyword. While flatc supports just `_` as an identifier I didn't consider this relevant because I don't think anyone would want a schema with `table _ {}`.